### PR TITLE
fix console command handling

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/spigot/command/DiscordCommandSender.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/spigot/command/DiscordCommandSender.java
@@ -11,6 +11,9 @@ import net.dv8tion.jda.api.interactions.InteractionHook;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.conversations.Conversation;
+import org.bukkit.conversations.ConversationAbandonedEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
@@ -22,7 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("NullableProblems")
-public class DiscordCommandSender implements CommandSender {
+public class DiscordCommandSender implements ConsoleCommandSender {
     private CompletableFuture<Message> cmdMessage;
     private final CompletableFuture<InteractionHook> cmdMsg;
     public final StringBuilder message = new StringBuilder();
@@ -256,5 +259,40 @@ public class DiscordCommandSender implements CommandSender {
     @Override
     public void setOp(boolean value) {
         Bukkit.getConsoleSender().setOp(value);
+    }
+
+    @Override
+    public boolean isConversing() {
+        return Bukkit.getConsoleSender().isConversing();
+    }
+
+    @Override
+    public void acceptConversationInput(@NotNull String input) {
+        Bukkit.getConsoleSender().acceptConversationInput(input);
+    }
+
+    @Override
+    public boolean beginConversation(@NotNull Conversation conversation) {
+        return Bukkit.getConsoleSender().beginConversation(conversation);
+    }
+
+    @Override
+    public void abandonConversation(@NotNull Conversation conversation) {
+        Bukkit.getConsoleSender().abandonConversation(conversation);
+    }
+
+    @Override
+    public void abandonConversation(@NotNull Conversation conversation, @NotNull ConversationAbandonedEvent details) {
+        Bukkit.getConsoleSender().abandonConversation(conversation, details);
+    }
+
+    @Override
+    public void sendRawMessage(@NotNull String message) {
+        Bukkit.getConsoleSender().sendRawMessage(message);
+    }
+
+    @Override
+    public void sendRawMessage(@Nullable UUID sender, @NotNull String message) {
+        Bukkit.getConsoleSender().sendRawMessage(sender, message);
     }
 }

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/spigot/util/SpigotServerInterface.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/spigot/util/SpigotServerInterface.java
@@ -59,9 +59,12 @@ public class SpigotServerInterface implements McServerInterface {
     public String runMCCommand(String cmd) {
         final DiscordCommandSender s = new DiscordCommandSender();
         try {
-            Bukkit.dispatchCommand(s, cmd.trim());
+            Bukkit.getScheduler().callSyncMethod(DiscordIntegrationPlugin.INSTANCE, () -> {
+                Bukkit.dispatchCommand(s, cmd.trim());
+                return null;
+            }).get();
             return s.message.toString();
-        } catch (CommandException e) {
+        } catch (Exception e) {
             return e.getMessage();
         }
     }


### PR DESCRIPTION
## Summary
- ensure runMCCommand schedules commands on main thread
- keep output for discord

## Testing
- `./gradlew test` *(fails to resolve dynmap-api 403)*

------
https://chatgpt.com/codex/tasks/task_e_6857fd41c6d0832395029a342a815487